### PR TITLE
Afficher la possibilité de rentrer les stats

### DIFF
--- a/components/PermanenceCard/PermanenceCardPopover.jsx
+++ b/components/PermanenceCard/PermanenceCardPopover.jsx
@@ -523,7 +523,7 @@ const PermanenceCardPopover = ({ permanence, onSubmit, onCancel }) => {
             <Can not I={MODIFY} this={COMPOSTER_PERMANENCE_MESSAGE}>
               {mayRenderEventMessage(permanence.eventTitle, permanence.eventMessage)}
             </Can>
-            {isPermanencePassed && mayRenderInnerFormStats(formikProps, onCancel)}
+            {mayRenderInnerFormStats(formikProps, onCancel)}
             {renderSubmitCancelButtons(formikProps.dirty, onCancel, formikProps.isSubmitting)}
           </Form>
         )


### PR DESCRIPTION
Lors d'une permanence, on est souvent obligé de noter le nombre de déposants ainsi que le poids, la température, etc à côté. Puis d'attendre que la permanence soit passée afin de pouvoir entrer les chiffres. Il arrive bien souvent que l'on oublie tout simplement de le faire, alors qu'on pourrait le faire en direct. Il me semble dommage de se passer de cette possibilité, c'est pourquoi je propose d'ôter la condition qui vérifie que la permanence est passée. 
Il se peut que je passe à côté d'une contrainte métier, en tout cas, je serai ravi d'en discuter !